### PR TITLE
#56: Spark 클러스터 크기 조절

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+	//Json파싱
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/example/K8s/kubernetes/CR/sparkcr/Metadata.java
+++ b/server/src/main/java/com/example/K8s/kubernetes/CR/sparkcr/Metadata.java
@@ -8,14 +8,18 @@ import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "name"
+        "name",
+        "resourceVersion"
 })
 @Generated("jsonschema2pojo")
 public class Metadata {
     @JsonProperty("name")
     private String name;
+    @JsonProperty("resourceVersion")
+    private String resourceVersion;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
 
     @JsonProperty("name")
     public String getName() {
@@ -26,6 +30,12 @@ public class Metadata {
     public void setName(String name) {
         this.name = name;
     }
+
+    @JsonProperty("resourceVersion")
+    public String getResourceVersion() {return resourceVersion;}
+
+    @JsonProperty("resourceVersion")
+    public void setResourceVersion(String resourceVersion) {this.resourceVersion = resourceVersion;}
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {

--- a/server/src/main/java/com/example/K8s/kubernetes/cluster/controller/ClusterController.java
+++ b/server/src/main/java/com/example/K8s/kubernetes/cluster/controller/ClusterController.java
@@ -39,4 +39,20 @@ public class ClusterController {
         log.error("클러스터 생성 실패");
         return "생성 실패";
     }
+
+    // 클러스터 수정
+    @PostMapping("/adj")
+    public String modifyCluster(ClusterRegDto adjDto) throws IOException{
+        if(adjDto.getType() == 0){
+//            hadoopService.modifyHadoopCluster(adjDto);
+            log.info("hadoop cluster 수정 완료");
+            return "hadoop cluster 수정 완료";
+        }
+        else if(adjDto.getType()==1){
+            sparkService.replaceSparkCluster(adjDto);
+            log.info("spark cluster 수정 완료");
+            return "spark cluster 수정 완료";
+        }
+        return "수정 성공";
+    }
 }

--- a/server/src/main/java/com/example/K8s/kubernetes/cluster/dto/ClusterAdjDto.java
+++ b/server/src/main/java/com/example/K8s/kubernetes/cluster/dto/ClusterAdjDto.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Getter @Setter
 @NoArgsConstructor
-public class ClusterRegDto {
+public class ClusterAdjDto {
     private User user;
     private String name;
     private int amount;

--- a/server/src/main/java/com/example/K8s/kubernetes/cluster/service/SparkDeleteService.java
+++ b/server/src/main/java/com/example/K8s/kubernetes/cluster/service/SparkDeleteService.java
@@ -1,0 +1,32 @@
+package com.example.K8s.kubernetes.cluster.service;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
+import io.kubernetes.client.util.ClientBuilder;
+
+import java.io.IOException;
+
+public class SparkDeleteService {
+    public static void main(String[] args) throws IOException {
+        CustomObjectsApi apiInstance = new CustomObjectsApi(ClientBuilder.standard().build());
+        String group ="radanalytics.io";
+        String version ="v1";
+        String namespace ="spark";
+        String plural = "sparkclusters";
+        String name = "my-spark-cluster";
+        Integer gracePeriodSeconds = 1;
+        Boolean orphanDependants = true;
+        V1DeleteOptions body = new V1DeleteOptions();
+        try {
+            Object result = apiInstance.deleteNamespacedCustomObject(group, version, namespace, plural, name, gracePeriodSeconds, orphanDependants, null,null,body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling CustomObjectsApi#deleteNamespacedCustomObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}

--- a/server/src/main/java/com/example/K8s/kubernetes/cluster/service/SparkModifyService.java
+++ b/server/src/main/java/com/example/K8s/kubernetes/cluster/service/SparkModifyService.java
@@ -1,0 +1,73 @@
+package com.example.K8s.kubernetes.cluster.service;
+
+import com.example.K8s.kubernetes.CR.sparkcr.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.util.ClientBuilder;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+
+public class SparkModifyService {
+    //    public static boolean replaceSparkCluster(ClusterRegDto regDto) throws IOException {
+////        boolean exist = clusterRepository.existsByName(regDto.getName());
+////        if(!exist) return false;
+//
+//        // 클러스터 수정
+//        Cluster cluster = new Cluster(regDto);
+//        boolean success = replace_Spark_Cluster(cluster);
+//
+//        return true;
+//    }
+    public static SparkCluster resetCluster(String name, int amount, String resourceVersion) {
+        SparkCluster sparkCluster = new SparkCluster();
+        sparkCluster.setApiVersion("radanalytics.io/v1");
+        sparkCluster.setKind("SparkCluster");
+        Metadata metadata = new Metadata();
+        metadata.setName(name);
+        metadata.setResourceVersion(resourceVersion);
+        sparkCluster.setMetadata(metadata);
+        Spec spec = new Spec();
+        Worker worker = new Worker();
+        worker.setInstances(Integer.toString(amount));
+        spec.setWorker(worker);
+        Master master = new Master();
+        master.setInstances("1");
+        spec.setMaster(master);
+        sparkCluster.setSpec(spec);
+        return sparkCluster;
+    }
+
+    public static void main(String[] args) throws IOException {
+        CustomObjectsApi apiInstance = new CustomObjectsApi(ClientBuilder.standard().build());
+        String group = "radanalytics.io";
+        String version = "v1";
+        String namespace = "spark";
+        String plural = "sparkclusters";
+        String name = "my-spark-cluster";
+        try {
+            Object getobject = apiInstance.getNamespacedCustomObject(group, version, namespace, plural, name);
+            System.out.println(getobject);
+            // 파싱
+            LinkedTreeMap<Object,Object> t = (LinkedTreeMap) getobject;
+            Object metadata = t.get("metadata");
+            LinkedTreeMap<Object,Object> t1 = (LinkedTreeMap) metadata;
+            String resourceVersion = t1.get("resourceVersion").toString();
+            System.out.println(resourceVersion);
+
+            Object body = resetCluster("my-spark-cluster", 3,resourceVersion);
+            Object result = apiInstance.replaceNamespacedCustomObject(group, version, namespace, plural, name, body, null, null);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling CustomObjectsApi#replaceNamespacedCustomObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}

--- a/server/src/main/java/com/example/K8s/kubernetes/cluster/service/SparkService.java
+++ b/server/src/main/java/com/example/K8s/kubernetes/cluster/service/SparkService.java
@@ -1,11 +1,15 @@
 package com.example.K8s.kubernetes.cluster.service;
 
 import com.example.K8s.kubernetes.CR.sparkcr.*;
+import com.example.K8s.kubernetes.cluster.dto.ClusterAdjDto;
 import com.example.K8s.kubernetes.cluster.dto.ClusterRegDto;
 import com.example.K8s.kubernetes.cluster.model.Cluster;
 import com.example.K8s.kubernetes.cluster.model.Spark;
 import com.example.K8s.kubernetes.cluster.repository.ClusterRepository;
 import com.example.K8s.kubernetes.cluster.repository.SparkRepository;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.util.ClientBuilder;
@@ -41,7 +45,19 @@ public class SparkService {
         return true;
     }
 
-    public SparkCluster setCluster(String name, int amount){
+    public boolean replaceSparkCluster(ClusterRegDto regDto) throws IOException{
+        boolean exist = clusterRepository.existsByName(regDto.getName());
+        if(!exist) return false;
+
+        // 클러스터 수정
+        Cluster cluster = new Cluster(regDto);
+        boolean success = replace_Spark_Cluster(cluster);
+        if(!success)
+            return false;
+
+        return true;
+    }
+    public static SparkCluster setCluster(String name, int amount){
         SparkCluster sparkCluster = new SparkCluster();
         sparkCluster.setApiVersion("radanalytics.io/v1");
         sparkCluster.setKind("SparkCluster");
@@ -79,4 +95,55 @@ public class SparkService {
         }
         return true;
     }
+    public static String Parsing(Object customobject){
+        LinkedTreeMap<Object,Object> t = (LinkedTreeMap) customobject;
+        Object metadata = t.get("metadata");
+        LinkedTreeMap<Object,Object> t1 = (LinkedTreeMap) metadata;
+        String resourceVersion = t1.get("resourceVersion").toString();
+
+        return resourceVersion;
+    }
+    public static SparkCluster resetCluster(String name, int amount, String resourceVersion) {
+        SparkCluster sparkCluster = new SparkCluster();
+        sparkCluster.setApiVersion("radanalytics.io/v1");
+        sparkCluster.setKind("SparkCluster");
+        Metadata metadata = new Metadata();
+        metadata.setName(name);
+        metadata.setResourceVersion(resourceVersion);
+        sparkCluster.setMetadata(metadata);
+        Spec spec = new Spec();
+        Worker worker = new Worker();
+        worker.setInstances(Integer.toString(amount));
+        spec.setWorker(worker);
+        Master master = new Master();
+        master.setInstances("1");
+        spec.setMaster(master);
+        sparkCluster.setSpec(spec);
+        return sparkCluster;
+    }
+
+    public boolean replace_Spark_Cluster(Cluster cluster) throws IOException{
+        CustomObjectsApi apiInstance = new CustomObjectsApi(ClientBuilder.standard().build());
+        String group ="radanalytics.io";
+        String version ="v1";
+        String namespace ="spark";
+        String plural = "sparkclusters";
+        String name = cluster.getName();
+        try {
+            Object getobject = apiInstance.getNamespacedCustomObject(group, version, namespace, plural, name);
+            String resourceVersion = Parsing(getobject);
+            Object body = resetCluster("my-spark-cluster", 3,resourceVersion);
+            Object result = apiInstance.replaceNamespacedCustomObjectScale(group, version, namespace, plural, name, body, null, null);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling CustomObjectsApi#replaceNamespacedCustomObjectScale");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+
+        return true;
+    }
+
 }


### PR DESCRIPTION
입력받은 개수에 맞게 이미 존재하는 spark 클러스터의 개수를 조절한다.
이때, replaceNamespacedCustomObject API를 활용한다.