### PR TITLE
Hotfix

### DIFF
--- a/client/src/components/Login/LoginEmail.js
+++ b/client/src/components/Login/LoginEmail.js
@@ -34,7 +34,7 @@ export default function LoginEmail({ setToken }) {
           window.localStorage.setItem('token', response.data.token);
           setToken(response.data.token);
           console.log(response);
-          alert('Success in login!');
+          // alert('Success in login!');
           navigate('/');
         })
         .catch(error => {

--- a/client/src/components/MyPage/ClusterManagementDialog/IncreaseDecreaseNodeDialog.js
+++ b/client/src/components/MyPage/ClusterManagementDialog/IncreaseDecreaseNodeDialog.js
@@ -20,7 +20,7 @@ export default function IncreaseDecreaseNodeDialog({ open, setOpen, cluster, opt
 
   const handleCloseDialog = () => {
     setOpen(false);
-    setAmount(0);
+    // setAmount(0);
   };
 
   const handleOpenSnackbar = () => {


### PR DESCRIPTION
클러스터 노드 개수 증가/감소 다이얼로그를 닫을 때 amount state를 0으로 설정하면
다이얼로그가 새로 open 되었을 때 값 입력 전까지 OK 버튼을 비활성화할 수 있지만,
노드 개수 증감 진행 상태를 확인할 수 없어 스낵바에 완료 메세지를 띄우지 못한다.

따라서 해당 코드를 주석 처리하여
스낵바에 노드 개수 증감 완료 메세지가 출력되지 않는 현상을 해결한다.